### PR TITLE
v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.1.1] - 2020-06-11
+### Changed
+- README now includes a version badge 😉.
+
+### Fixed
+- When using on proyects with different `bundler` versions the gem wouldn't run,
+  so the way the gems where being checked was changed from using
+  `Bundler.load.specs` to `File.read('Gemfile.lock')`
+
 ## [0.1.0] - 2020-06-11
 ### Added
 - Basic repo setup.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lollipop (0.1.0)
+    lollipop (0.1.1)
 
 GEM
   remote: https://rubygems.org/
@@ -114,10 +114,10 @@ GEM
       mixlib-cli
     sexp_processor (4.15.0)
     shellany (0.0.1)
-    sorbet (0.5.5742)
-      sorbet-static (= 0.5.5742)
-    sorbet-runtime (0.5.5742)
-    sorbet-static (0.5.5742-universal-darwin-14)
+    sorbet (0.5.5745)
+      sorbet-static (= 0.5.5745)
+    sorbet-runtime (0.5.5745)
+    sorbet-static (0.5.5745-universal-darwin-14)
     thor (0.20.3)
     unicode-display_width (1.7.0)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Lollipop
+# Lollipop [![Gem Version](https://badge.fury.io/rb/lollipop.svg)](https://badge.fury.io/rb/lollipop)
 
 Lollipop intends to help you set up a repo for fast development. For now, it
 checks for the precense of a specific list of gems.

--- a/exe/lollipop
+++ b/exe/lollipop
@@ -4,7 +4,7 @@
 require 'bundler/setup'
 require_relative '../lib/lollipop'
 
-@gems = Bundler.load.specs.map(&:name)
+@gems = File.read('Gemfile.lock').split
 
 def log_installed_gem(gem)
   puts "\u{1f44d} #{gem}"

--- a/lib/lollipop/version.rb
+++ b/lib/lollipop/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module Lollipop
-  VERSION = '0.1.0'
+  VERSION = '0.1.1'
 end


### PR DESCRIPTION
## [0.1.1] - 2020-06-11
### Changed
- README now includes a version badge 😉.

### Fixed
- When using on proyects with different `bundler` versions the gem wouldn't run,
  so the way the gems where being checked was changed from using
  `Bundler.load.specs` to `File.read('Gemfile.lock')`